### PR TITLE
Utilize the sparsity of the r vector

### DIFF
--- a/R/get_structure_constants.R
+++ b/R/get_structure_constants.R
@@ -55,11 +55,9 @@ get_structure_constants <- function(perm) {
   )
 
   r <- calculate_r(cycle_lengths, perm_order)
-  d <- calculate_d(perm_order)
+  L <- length(r)
+  d <- calculate_d(L, perm_order)
 
-  L <- sum(r > 0)
-  d <- d[r > 0]
-  r <- r[r > 0]
   k <- d
   dim_omega <- r + r * (r - 1) * d / 2
 
@@ -93,8 +91,11 @@ get_cycle_representatives_and_lengths <- function(perm) {
 }
 
 #' Calculate structure constant r
+#' Utilizes the sparsity for the `r_alfa` to speed up the computation.
+#' The vector `r_alfa` is sorted by the value of the `alpha`.
+#' Meaning the first element is the `r_alpha` for `alpha` = 0.
 #'
-#' @returns An integer vector. Structure constant r WITH elements equal to 0.
+#' @returns An integer vector. Structure constant r already without 0 elements.
 #' @noRd
 calculate_r <- function(cycle_lengths, perm_order) {
   M <- floor(perm_order / 2)
@@ -102,36 +103,26 @@ calculate_r <- function(cycle_lengths, perm_order) {
     # identity function
     return(length(cycle_lengths))
   }
-  # for a in 0,1,...,floor(perm_order/2)
-  # r_a = #{1:C such that a*p_c is a multiple of N}
-  # AKA a*p_c %% N == 0
 
-  # Corollary: N %% p_c == 0 for each p_c, cause N is LCM of all p_c
   multiples <- round(perm_order / cycle_lengths) # the result of division should be an integer, but floats may interfere
 
-  # Now we have to adjust for 2 cases:
-  # 1) some alphas are too large
-  # 2) some alphas are so small, that we can include their multiples
-  #   (if a*p_c %% N == 0, then for any natural k  k*a*p_c %% N == 0)
-  alphas <- unlist(lapply(multiples, function(cycle_multiple) {
-    max_multiple <- floor(M / cycle_multiple)
-    cycle_multiple * 0:max_multiple
-  }))
+  max_order <- max(cycle_lengths)
+  alpha_matrix <- multiples %*% t(0:max_order)
+  possible_alphas <- unique(sort(alpha_matrix[alpha_matrix <= M]))
 
-  alpha_count <- table(alphas)
-  r <- rep(0, M + 1)
-  r[as.double(names(alpha_count)) + 1] <- as.double(alpha_count)
-  r
+  r_alfa <- sapply(possible_alphas, function(alpha) sum(alpha %% multiples == 0))
+  as.double(r_alfa)
 }
 
-#' Calculate structure constant d
+#' Calculate structure constant d.
+#' Utilizing the structure of `r_alfa` vector.
 #'
 #' @noRd
-calculate_d <- function(perm_order) {
-  M <- floor(perm_order / 2)
-  d <- c(1, rep(2, M))
+calculate_d <- function(r_len, perm_order) {
+  d <- rep(2, r_len)
+  d[1] <- 1
   if (perm_order %% 2 == 0) {
-    d[M + 1] <- 1
+    d[r_len] <- 1
   }
   d
 }

--- a/tests/testthat/test-get_structure_constants.R
+++ b/tests/testthat/test-get_structure_constants.R
@@ -27,10 +27,10 @@ test_that("get_structure_constants for examples from paper", {
 })
 
 # Example 6 from the paper
-test_that("calculate_r works for example from paper", {
+test_that("calculate_r works for example from paper (without 0 values)", {
   expect_equal(
     calculate_r(c(3, 2, 1), 6),
-    c(3, 0, 1, 1)
+    c(3, 1, 1)
   )
 })
 
@@ -42,18 +42,18 @@ test_that("calculate_r works for identity", {
 })
 
 test_that("calculate_d works for even perm_order", {
-  expect_equal(calculate_d(6), c(1, 2, 2, 1))
-  expect_equal(calculate_d(4), c(1, 2, 1))
-  expect_equal(calculate_d(2), c(1, 1))
+  expect_equal(calculate_d(4, 6), c(1, 2, 2, 1))
+  expect_equal(calculate_d(3, 4), c(1, 2, 1))
+  expect_equal(calculate_d(2, 2), c(1, 1))
 })
 
 test_that("calculate_d works for odd perm_order", {
-  expect_equal(calculate_d(5), c(1, 2, 2))
-  expect_equal(calculate_d(3), c(1, 2))
+  expect_equal(calculate_d(3, 5), c(1, 2, 2))
+  expect_equal(calculate_d(2, 3), c(1, 2))
 })
 
 test_that("calculate_d works for identity", {
-  expect_equal(calculate_d(1), 1)
+  expect_equal(calculate_d(1, 1), 1)
 })
 
 test_that("get_structure_constants checks for proper argument", {


### PR DESCRIPTION
# Utilize the sparsity of the r vector

It would be best to explain by example:

Let suppose that we have a vector of permutation lengths (2, 3, 5, 7, 11, 13, 17, 19, 23, 29).
Those are prime numbers so the order is equal to the product of all the terms = 6,469,693,230 (6 billion+).

The previous solution stored two vectors `r` and `d` of length roughly `order / 2` and then we removed the elements from that `r` vector that ever equal to 0.

## Observation:
The way that this `r` vector is constructed makes it spare for large number of co-prime permutation lengths. 

## Modification:
Instead computing the `r_alfa` for all `alfa` values and then removing elements = 0, first find a much smaller set of possible alpha values that result in non 0 elements (simple number theory) and then compute the exact `r_alfa` value for only those alpha. 

## Benchmark:
 ```r
 perm_size <- 200
microbenchmark::microbenchmark(
  {
    perm <- gips::gips_perm(permutations::rperm(1, perm_size), perm_size)
    gips::get_structure_constants(perm)
  },
  times = 1000,
  unit = "ms"
)
```

### Before
```
     min        lq     mean    median      uq      max neval
 0.82605 0.9627325 1.773829 0.9944785 1.02673 697.5169  1000
```

### After
```
      min       lq     mean  median       uq      max neval
 0.798178 0.910296 1.037912 0.94426 0.981323 41.76067  1000
```
 
## Additional: 
The memory footprint of the algorithm decreased drastically. 
Previous solution crashed trying to allocate 100GB of RAM on encountering large permutation of size 300
